### PR TITLE
fix: Broken ECR Scan results link

### DIFF
--- a/function/lambda_function.py
+++ b/function/lambda_function.py
@@ -65,7 +65,7 @@ def get_params(scan_result):
                     scan_result['imageTags'][0]}''',
                 'title_link': f'''https://console.aws.amazon.com/ecr/repositories/{
                     scan_result['repositoryName']}/image/{
-                    scan_result['imageDigest']}/scan-results?region={region}''',
+                    scan_result['imageDigest']}/scan-results/?region={region}''',
                 'text': f'''{description}\nImage Scan Completed at {
                     complete_at}\nVulnerability Source Updated at {source_update_at}''',
                 'fields': [


### PR DESCRIPTION
Scan results URL should be .../repo-name/image/sha256:123/scan-results/region=region

Fixes #
* Fix - Broken Scan Result URL in Slack message